### PR TITLE
Pass Consent API URL as parameter to client JS

### DIFF
--- a/haas/__init__.py
+++ b/haas/__init__.py
@@ -1,4 +1,6 @@
 """Hexagrams as a Service Flask app."""
+import os
+
 from flask import Flask
 from flask_assets import Environment
 from jinja2 import ChoiceLoader
@@ -8,6 +10,8 @@ from jinja2 import PrefixLoader
 app = Flask(__name__, static_url_path="/assets")
 assets = Environment(app)
 assets.from_module("haas.assets")
+
+app.jinja_env.globals["getenv"] = os.getenv
 
 app.jinja_loader = ChoiceLoader(
     [

--- a/haas/templates/base.html
+++ b/haas/templates/base.html
@@ -138,5 +138,10 @@
   <script src="{{ url_for('static', filename='govuk-frontend-4.1.0.min.js') }}"></script>
   <script>window.GOVUKFrontend.initAll()</script>
   {% assets "cookies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      window.ConsentAPIClient = new Consent();
+      window.ConsentAPIClient.init({"host": "{{ getenv('CONSENT_API_HOST') }}"})
+    })
+  </script>
 {% endblock %}

--- a/makefile
+++ b/makefile
@@ -44,7 +44,7 @@ assets: consent_api
 
 .PHONY: run
 run:
-	flask --debug run --debugger --reload
+	flask --debug run --debugger --reload --port $(PORT)
 
 .PHONY: docker-image
 docker-image: assets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@alphagov/consent-api": "github:@alphagov/consent-api#semver:1.4.5",
+    "@alphagov/consent-api": "github:@alphagov/consent-api#semver:1.4.8",
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.3"


### PR DESCRIPTION
* Pass the API URL as a parameter to the JS, allowing multiple environments and easier end-to-end testing